### PR TITLE
Correct css path for sortable table doc

### DIFF
--- a/docs/Sortable-Table.html
+++ b/docs/Sortable-Table.html
@@ -508,7 +508,7 @@
         }
     </style>
 
-    <link rel="stylesheet" href="../applications/tables/sortable-table/ila-sortable-table.css"></style>
+    <link rel="stylesheet" href="../css/ila-sortable-table.css"></style>
     <!-- Script used for example only -->
     <script src="https://www.w3.org/WAI/content-assets/wai-aria-practices/patterns/table/examples/js/sortable-table.js"></script>
 </head>


### PR DESCRIPTION
The CSS path to `il-sortable-table.css` was incorrect in the `Sortable-Table.html` doc.