### PR TITLE
Fix command to find JavaScript files

### DIFF
--- a/setuppages.sh
+++ b/setuppages.sh
@@ -1,4 +1,5 @@
 mkdir -p ./docs/css
 mkdir -p ./docs/js
-find ./applications -name *.js -exec cp {} ./docs/js \;
+find ./applications -iregex .*[.]js$ -exec cp {} ./docs/js \;
 find ./applications -name *.css -exec cp {} ./docs/css \;
+


### PR DESCRIPTION
## Context 

JavaScript files below the `applications` folder were not being imported into `doc` for the demo site as expected.

## Updates

+ Switch to case insensitive regular expression for finding JavaScript files