### PR TITLE
Support lifecycle text update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,23 +5,6 @@ Notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Product Lifecycle
-
-This product is supported by the Application Development UX Standards Working Group at the University of Illinois on a best-effort basis.
-
-As of the last update to this README, possible End-of-Life and End-of-Support dates of this product are June 2026.
-
-Web browsers provide very short official support windows (if any). 
-This date should roll forward as future browser releases become available.
-
-End-of-Life was decided based on these dependencies:
-
-- Firefox Extended Support Release (ESR) 115 (Support Ends March 2025 - https://whattrainisitnow.com/release/?version=esr)
-- Firefox ESR 128 (Support Ends Sep 2025)
-- Firefox ESR 140 (Support Ends June 2026)
-- Google Chrome (Support Ends 8 weeks after release - https://chromium.googlesource.com/chromium/src/+/master/docs/process/release_cycle.md)
-- Microsoft Edge (Support Ends 16 weeks after release- https://learn.microsoft.com/en-us/deployedge/microsoft-edge-support-lifecycle)
-
 ## [Unreleased]
 
 ### Added
@@ -44,3 +27,19 @@ End-of-Life was decided based on these dependencies:
 - Toasts
 - Tooltip
 
+## Product Lifecycle
+
+This product is supported by the Application Development UX Standards Working Group at the University of Illinois on a best-effort basis.
+
+As of the last update to this README, possible End-of-Life and End-of-Support dates of this product are June 2026.
+
+Web browsers provide very short official support windows (if any). 
+This date should roll forward as future browser releases become available.
+
+End-of-Life was decided based on these dependencies:
+
+- Firefox Extended Support Release (ESR) 115 (Support Ends March 2025 - https://whattrainisitnow.com/release/?version=esr)
+- Firefox ESR 128 (Support Ends Sep 2025)
+- Firefox ESR 140 (Support Ends June 2026)
+- Google Chrome (Support Ends 8 weeks after release - https://chromium.googlesource.com/chromium/src/+/master/docs/process/release_cycle.md)
+- Microsoft Edge (Support Ends 16 weeks after release- https://learn.microsoft.com/en-us/deployedge/microsoft-edge-support-lifecycle)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,17 +31,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 This product is supported by the Application Development UX Standards Working Group at the University of Illinois on a best-effort basis.
 
-As of the last update to this README, possible End-of-Life and End-of-Support dates of this product are June 2029.
-This date should roll forward as future browser releases become available.
+As of the last update to this README, End-of-Life and End-of-Support dates of this product are June 2029.
+This date may roll forward as future browser releases become available and the code is verified on them.
 
-Web browsers provide very short official support windows (if any).
-But an examintation of the history of the shared EMCA Script Standard (for JavaScript) suggests minor breaking changes roughly every five years, from each annual June update.
+Web browsers provide very short official support windows (if any), but history of the shared EMCA Script Standard (for JavaScript) reveals minor breaking changes roughly every five years, during annual June updates.
+
+The strongest factor for our ed-of-life date is the lifecycle of ECMAScript, the shared cross-browser JavaScript implementation standard. The ECMAScript standard is updated annually in June. [The ISO ECMA Script Specification has a 5 year lifecycle](https://www.iso.org/standard/73002.html). 
+
+[ECMA Script 2024 introduces minor breaking changes for JavaScript code written targeting the ECMAScript 2019 Standard and earlier versions.](https://262.ecma-international.org/15.0/#sec-additions-and-changes-that-introduce-incompatibilities-with-prior-editions). Searching for more than minor breaking changes, we find that [ECMAScript 2009 included substantial breaking changes from previous versions.](https://en.wikipedia.org/wiki/ECMAScript_version_history).
 
 End-of-Life was decided based on these dependencies:
 
+- ECMAScript -  An conservative esimtate of earliest likely breaking changes for this effort, due to changes in the ECMAScript Standard, is June 2029.
 - Firefox Extended Support Release (ESR) 115 (Support Ends March 2025 - https://whattrainisitnow.com/release/?version=esr)
 - Firefox ESR 128 (Support Ends Sep 2025)
 - Firefox ESR 140 (Support Ends June 2026)
 - Google Chrome (Support Ends 8 weeks after release - https://chromium.googlesource.com/chromium/src/+/master/docs/process/release_cycle.md)
 - Microsoft Edge (Support Ends 16 weeks after release- https://learn.microsoft.com/en-us/deployedge/microsoft-edge-support-lifecycle)
-- ECMAScript - The shared cross-browser JavaScript implementation standard. The ECMAScript standard is updated annually in June. [The ISO ECMA Script Specificationhas a 5 year lifecycle](https://www.iso.org/standard/73002.html). [ECMA Script 2024 introduces minor breaking changes for JavaScript code written targeting the ECMAScript 2019 Standard and earlier versions.](https://262.ecma-international.org/15.0/#sec-additions-and-changes-that-introduce-incompatibilities-with-prior-editions). Searching for more than minor breaking changes, we find that [ECMAScript 2009 included substantial breaking changes from previous versions.](https://en.wikipedia.org/wiki/ECMAScript_version_history). An conservative esimtate of earliest likely breaking changes for this effort, due to changes in the ECMAScript Standard, is June 2029.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,10 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 This product is supported by the Application Development UX Standards Working Group at the University of Illinois on a best-effort basis.
 
-As of the last update to this README, possible End-of-Life and End-of-Support dates of this product are June 2026.
-
-Web browsers provide very short official support windows (if any). 
+As of the last update to this README, possible End-of-Life and End-of-Support dates of this product are June 2029.
 This date should roll forward as future browser releases become available.
+
+Web browsers provide very short official support windows (if any).
+But an examintation of the history of the shared EMCA Script Standard (for JavaScript) suggests minor breaking changes roughly every five years, from each annual June update.
 
 End-of-Life was decided based on these dependencies:
 
@@ -43,3 +44,4 @@ End-of-Life was decided based on these dependencies:
 - Firefox ESR 140 (Support Ends June 2026)
 - Google Chrome (Support Ends 8 weeks after release - https://chromium.googlesource.com/chromium/src/+/master/docs/process/release_cycle.md)
 - Microsoft Edge (Support Ends 16 weeks after release- https://learn.microsoft.com/en-us/deployedge/microsoft-edge-support-lifecycle)
+- ECMAScript - The shared cross-browser JavaScript implementation standard. The ECMAScript standard is updated annually in June. [The ISO ECMA Script Specificationhas a 5 year lifecycle](https://www.iso.org/standard/73002.html). [ECMA Script 2024 introduces minor breaking changes for JavaScript code written targeting the ECMAScript 2019 Standard and earlier versions.](https://262.ecma-international.org/15.0/#sec-additions-and-changes-that-introduce-incompatibilities-with-prior-editions). Searching for more than minor breaking changes, we find that [ECMAScript 2009 included substantial breaking changes from previous versions.](https://en.wikipedia.org/wiki/ECMAScript_version_history). An conservative esimtate of earliest likely breaking changes for this effort, due to changes in the ECMAScript Standard, is June 2029.


### PR DESCRIPTION
+ Re-order CHANGELOG to put most important information (what has changed) first.
+ Updated estimated end-of-life to June 2029, due based on the last release (June 2024) and history of known breaking changes in the shared ECMAScript Standard (roughly 5 year lifecycle).