### PR TITLE
Various Updates for Issue 133

### DIFF
--- a/applications/ila-cookie-banner/ila-cookie-banner.css
+++ b/applications/ila-cookie-banner/ila-cookie-banner.css
@@ -222,11 +222,15 @@
     }
 }
 
-.ila-cookieb-noscroll {
-    overflow: hidden;
-}
+/* Used to enable or disable scroll on the page */
 
-.ila-cookieb-modal {
+/* .ila-cookieb-noscroll {
+    overflow: hidden;
+} */
+
+/* Used to enable or disable a modal background on the page  */
+
+/* .ila-cookieb-modal {
     position: fixed;
     z-index: 2000;
     top: 0;
@@ -234,4 +238,5 @@
     right: 0;
     left: 0;
     background-color: #24242496;
-}
+} *
+ 

--- a/applications/ila-cookie-banner/ila-cookie-banner.css
+++ b/applications/ila-cookie-banner/ila-cookie-banner.css
@@ -54,7 +54,8 @@
 }
 
 .ila-cookieb__button-close-slideover:hover,
-.ila-cookieb__button-close-slideover:focus {
+.ila-cookieb__button-close-slideover:focus,
+.ila-cookieb__button-close-slideover:active {
     transition: background-color 0.3s;
     background-color: var(--ila-cookieb-hover-orange);
     color: white;
@@ -74,17 +75,18 @@
 }
 
 .ila-cookieb__close-button:hover,
-.ila-cookieb__close-button:focus {
+.ila-cookieb__close-button:focus,
+.ila-cookieb__close-button:active {
     transition: background-color 0.3s;
     background-color: var(--ila-cookieb-hover-orange);
     color: white;
 }
 
 .ila-cookieb__button:hover,
-.ila-cookieb__button:focus {
+.ila-cookieb__button:focus,
+.ila-cookieb__button:active {
     background-color: var(--ila-cookieb-hover-orange);
 }
-
 
 .ila-cookieb__close-icon {
     padding: var(--ila-cookieb-padding-y) var(--ila-cookieb-padding-x);
@@ -145,6 +147,7 @@
 }
 
 /* UIUC Branding */
+
 .ila-cookieb__cookieb {
     color: var(--ila-cookieb-font-white);
     background-color: var(--ila-cookieb-background-blue);
@@ -156,8 +159,62 @@
 
 /* Hide Cookie Banner when Printing */
 
-@media print{    
+@media print {
     .ila-cookieb_no-printing {
         display: none !important;
+    }
+}
+
+.ila-cookieb__popup-info span {
+    display: none;
+}
+
+.ila-cookieb__popup-info:hover span,
+.ila-cookieb__popup-info:focus span,
+.ila-cookieb__popup-info:active span {
+    display: block;
+    position: absolute;
+    bottom: 2.5rem;
+    left: 10rem;
+    padding: 1rem;
+    background-color: var(--il-blue);
+    color: #ffffff;
+    border-style: solid;
+    border-color: var(--il-orange);
+}
+
+@media (max-width: 1030px) {
+
+    .ila-cookieb__popup-info:hover span,
+    .ila-cookieb__popup-info:focus span,
+    .ila-cookieb__popup-info:active span {
+        bottom: 7rem;
+    }
+}
+
+.ila-cookieb__popup-info-slideout span {
+    display: none;
+}
+
+.ila-cookieb__popup-info-slideout:hover span,
+.ila-cookieb__popup-info-slideout:focus span,
+.ila-cookieb__popup-info-slideout:active span {
+    display: block;
+    position: absolute;
+    bottom: 2.5rem;
+    left: 10rem;
+    padding: 1rem;
+    background-color: var(--il-blue);
+    color: #ffffff;
+    border-style: solid;
+    border-color: var(--il-orange);
+}
+
+@media (max-width: 1030px) {
+
+    .ila-cookieb__popup-info-slideout:hover span,
+    .ila-cookieb__popup-info-slideout:focus span,
+    .ila-cookieb__popup-info-slideout:active span {
+        bottom: 7rem;
     }
 }

--- a/applications/ila-cookie-banner/ila-cookie-banner.css
+++ b/applications/ila-cookie-banner/ila-cookie-banner.css
@@ -23,7 +23,7 @@
 }
 
 .ila-cookieb__h3 {
-    margin: 0 0 auto auto;
+    margin: 0.5rem 0 auto auto;
 }
 
 .ila-cookieb__content p {
@@ -46,6 +46,18 @@
 
 .ila-cookieb__button {
     margin: 0 0 .5rem .5rem;
+}
+
+.ila-cookieb__button-center-slideover {
+    display: flex;
+    justify-content: center;
+}
+
+.ila-cookieb__button-close-slideover:hover,
+.ila-cookieb__button-close-slideover:focus {
+    transition: background-color 0.3s;
+    background-color: var(--ila-cookieb-hover-orange);
+    color: white;
 }
 
 .ila-cookieb__close-button {
@@ -101,6 +113,9 @@
     line-height: 1.2em;
 }
 
+.ila-cookieb__pointer_hover {
+    cursor: pointer;
+}
 
 /* allow buttons to slide underneath text on thin screens */
 
@@ -121,6 +136,14 @@
     }
 }
 
+/* Make Slideout wider on thin screens */
+
+@media (max-width: 1030px) {
+    .ila-slideover--left .ila-slideover__slideover {
+        right: 5% !important;
+    }
+}
+
 /* UIUC Branding */
 .ila-cookieb__cookieb {
     color: var(--ila-cookieb-font-white);
@@ -131,5 +154,10 @@
     color: var(--ila-cookieb-font-white);
 }
 
+/* Hide Cookie Banner when Printing */
 
-
+@media print{    
+    .ila-cookieb_no-printing {
+        display: none !important;
+    }
+}

--- a/applications/ila-cookie-banner/ila-cookie-banner.css
+++ b/applications/ila-cookie-banner/ila-cookie-banner.css
@@ -201,7 +201,7 @@
 .ila-cookieb__popup-info-slideout:active span {
     display: block;
     position: absolute;
-    bottom: 2.5rem;
+    bottom: auto;
     left: 10rem;
     padding: 1rem;
     background-color: var(--il-blue);
@@ -215,6 +215,6 @@
     .ila-cookieb__popup-info-slideout:hover span,
     .ila-cookieb__popup-info-slideout:focus span,
     .ila-cookieb__popup-info-slideout:active span {
-        bottom: 7rem;
+        bottom: auto;
     }
 }

--- a/applications/ila-cookie-banner/ila-cookie-banner.css
+++ b/applications/ila-cookie-banner/ila-cookie-banner.css
@@ -12,6 +12,7 @@
     bottom: 0;
     left: 0rem;
     width: auto;
+    z-index: 2000;
 }
 
 .ila-cookieb__cookieb {
@@ -98,6 +99,7 @@
     visibility: hidden;
     opacity: 0;
     order: 1;
+    position: absolute;
 }
 
 @media (prefers-reduced-motion) {
@@ -105,6 +107,7 @@
         visibility: hidden;
         opacity: 0;
         order: 1;
+        position: absolute;
     }
 }
 
@@ -217,4 +220,18 @@
     .ila-cookieb__popup-info-slideout:active span {
         bottom: auto;
     }
+}
+
+.ila-cookieb-noscroll {
+    overflow: hidden;
+}
+
+.ila-cookieb-modal {
+    position: fixed;
+    z-index: 2000;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    left: 0;
+    background-color: #24242496;
 }

--- a/applications/ila-cookie-banner/ila-cookie-banner.html
+++ b/applications/ila-cookie-banner/ila-cookie-banner.html
@@ -78,7 +78,7 @@
 <body onload="openCookieB('ilaCookieBOne', 'ilaCookieBFocusOnLoad', 'ilaCookieModal')">
     <il-page>
 
-        <div id="ilaCookieModal"></div>
+        <div id="ilaCookieModal" aria-modal="true"></div>
 
         <div class="cookieb-holder ila-cookieb_no-printing" role="alert">
             <div class="cookieb-holder-inner">
@@ -109,7 +109,8 @@
                             </p>
                             <div class="ila-cookieb__actions">
                                 <button type="button" class="il-button ila-cookieb__button"
-                                    onclick="openSlideover('ilaSlideoverLeft')" aria-label="learn about cookies">
+                                    onclick="openSlideover('ilaSlideoverLeft')"
+                                    aria-label="learn about cookies - opens modal dialogue">
                                     About Cookies
                                 </button>
                                 <button type="button" class="il-button ila-cookieb__button"
@@ -130,9 +131,9 @@
             <div class="ila-slideover__slideover">
                 <div class="ila-slideover__header">
                     <h2 id="ilaSlideoverLeftLabel" class="ila-slideover__label">
-                        Illinois
+                        University of Illinois - Cookie Information
                     </h2>
-                    <button type="button" aria-label="close slideover" class="ila-slideover__close-button"
+                    <button type="button" aria-label="close" class="ila-slideover__close-button"
                         onclick="closeSlideover('ilaSlideoverLeft')">
                         <div class="ila-slideover__close-icon il-icon" role="presentation">
                             cancel

--- a/applications/ila-cookie-banner/ila-cookie-banner.html
+++ b/applications/ila-cookie-banner/ila-cookie-banner.html
@@ -45,12 +45,17 @@
         .button-holder button {
             margin-right: 5px;
         }
+
+        .page-wrapper {
+            margin: 30px auto 0 auto;
+            padding: 0 30px;
+        }
     </style>
 </head>
 
 <body onload="openCookieB('ilaCookieBOne')">
     <il-page>
-        <div class="cookieb-holder" role="alert">
+        <div class="cookieb-holder ila-cookieb_no-printing" role="alert">
             <div class="cookieb-holder-inner">
                 <div id="ilaCookieBOne" class="ila-cookieb ila-cookieb--closed">
                     <div class="ila-cookieb__cookieb">
@@ -88,8 +93,9 @@
                 </div>
             </div>
         </div>
-        <div id="ilaSlideoverLeft" class="ila-slideover ila-slideover--closed ila-slideover--left" role="dialog"
-            aria-labelledby="ilaSlideoverLeftLabel" aria-modal="true">
+        <div id="ilaSlideoverLeft" 
+            class="ila-slideover ila-slideover--closed ila-slideover--left ila-cookieb_no-printing" 
+            role="dialog" aria-labelledby="ilaSlideoverLeftLabel" aria-modal="true">
             <div class="ila-slideover__overlay" onclick="closeSlideover('ilaSlideoverLeft')"></div>
             <div class="ila-slideover__slideover">
                 <div class="ila-slideover__header">
@@ -125,7 +131,9 @@
                             Illinois System Cookie Policy</a> for more information.
                     </p>
                     <details>
-                        <summary>Strictly Necessary Cookies - Always Active</summary>
+                        <summary class="ila-cookieb__pointer_hover">
+                            Strictly Necessary Cookies - Always Active
+                        </summary>
                         <p class="ila-cookieb__slide_small">
                             Strictly Necessary Cookies are first-party Cookies that are necessary for the website to
                             function. They can be either permanent or temporary and are usually only set in response to
@@ -137,7 +145,9 @@
                             the site will not work.</p>
                     </details>
                     <details>
-                        <summary>Performance Cookies - Always Active</summary>
+                        <summary  class="ila-cookieb__pointer_hover">
+                            Performance Cookies - Always Active
+                        </summary>
                         <p class="ila-cookieb__slide_small">
                             Performance Cookies allow us to count visits and traffic sources so we can measure and
                             improve the performance and effectiveness of University websites. Performance Cookies also
@@ -154,7 +164,9 @@
                             work.</p>
                     </details>
                     <details>
-                        <summary>Functional Cookies - Always Active</summary>
+                        <summary class="ila-cookieb__pointer_hover">
+                            Functional Cookies - Always Active
+                        </summary>
                         <p class="ila-cookieb__slide_small">
                             Functional Cookies enhance the performance and functionality of our websites but are
                             non-essential to their use. These permanent Cookies allow our website to remember
@@ -165,7 +177,9 @@
                             Cookies, some or all of these services may not function properly.</p>
                     </details>
                     <details>
-                        <summary>Targeting Cookies - Always Active</summary>
+                        <summary class="ila-cookieb__pointer_hover">
+                            Targeting Cookies - Always Active
+                        </summary>
                         <p class="ila-cookieb__slide_small">
                             Targeting Cookies are used to deliver content tailored to your interests and may be
                             temporary or permanent. They may also be first-party or third-party Cookies. Targeting
@@ -183,7 +197,16 @@
                             that you have provided to them or that they have collected from your use of their services.
                             If you set your browser to block or delete Cookies, you will still see advertisements, but
                             they will be less targeted to your interests.</p>
+                    </details>
                 </div>
+                <div class="ila-cookieb__button-center-slideover">
+                    <button aria-label="close slideover" 
+                        class="il-button ila-cookieb__button-close-slideover"
+                        onclick="closeSlideover('ilaSlideoverLeft')"
+                    >
+                        Close
+                    </button>
+            </div>
             </div>
         </div>
     </il-page>

--- a/applications/ila-cookie-banner/ila-cookie-banner.html
+++ b/applications/ila-cookie-banner/ila-cookie-banner.html
@@ -75,8 +75,10 @@
     </style>
 </head>
 
-<body onload="openCookieB('ilaCookieBOne', 'ilaCookieBFocusOnLoad')">
+<body onload="openCookieB('ilaCookieBOne', 'ilaCookieBFocusOnLoad', 'ilaCookieModal')">
     <il-page>
+
+        <div id="ilaCookieModal"></div>
 
         <div class="cookieb-holder ila-cookieb_no-printing" role="alert">
             <div class="cookieb-holder-inner">
@@ -84,7 +86,7 @@
                     <div tabindex="0" id="ilaCookieBFocusOnLoad" class="ila-cookieb__cookieb"
                         aria-label="Cookie Banner">
                         <button type="button" class="ila-cookieb__close-button" aria-label="close cookie banner"
-                            onclick="closeCookieB('ilaCookieBOne')">
+                            onclick="closeCookieB('ilaCookieBOne', 'ilaCookieModal')">
                             <div class="ila-cookieb__close-icon il-icon" role="presentation">
                                 cancel
                             </div>
@@ -111,7 +113,8 @@
                                     About Cookies
                                 </button>
                                 <button type="button" class="il-button ila-cookieb__button"
-                                    onclick="closeCookieB('ilaCookieBOne')" aria-label="close cookie banner">
+                                    onclick="closeCookieB('ilaCookieBOne', 'ilaCookieModal')"
+                                    aria-label="close cookie banner">
                                     Close this Notice
                                 </button>
                             </div>

--- a/applications/ila-cookie-banner/ila-cookie-banner.html
+++ b/applications/ila-cookie-banner/ila-cookie-banner.html
@@ -75,13 +75,14 @@
     </style>
 </head>
 
-<body onload="openCookieB('ilaCookieBOne')">
+<body onload="openCookieB('ilaCookieBOne', 'ilaCookieBFocusOnLoad')">
     <il-page>
 
         <div class="cookieb-holder ila-cookieb_no-printing" role="alert">
             <div class="cookieb-holder-inner">
                 <div id="ilaCookieBOne" class="ila-cookieb ila-cookieb--closed">
-                    <div class="ila-cookieb__cookieb">
+                    <div tabindex="0" id="ilaCookieBFocusOnLoad" class="ila-cookieb__cookieb"
+                        aria-label="Cookie Banner">
                         <button type="button" class="ila-cookieb__close-button" aria-label="close cookie banner"
                             onclick="closeCookieB('ilaCookieBOne')">
                             <div class="ila-cookieb__close-icon il-icon" role="presentation">

--- a/applications/ila-cookie-banner/ila-cookie-banner.html
+++ b/applications/ila-cookie-banner/ila-cookie-banner.html
@@ -1,18 +1,40 @@
-<!DOCTYPE html>
-
-<html lang="en" class="il-toolkit">
+<!doctype html>
+<html lang="en-US">
 
 <head>
-    <meta charset="utf-8" />
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="profile" href="https://gmpg.org/xfn/11">
     <title>ILA CookieB</title>
+    <meta name='robots' content='max-image-preview:large' />
+    <link rel='dns-prefetch' href='//cdn.toolkit.illinois.edu' />
+    <link rel='dns-prefetch' href='//cdn.disability.illinois.edu' />
+    <link rel='dns-prefetch' href='//stackpath.bootstrapcdn.com' />
+    <link rel='dns-prefetch' href='//kit.fontawesome.com' />
+    <link rel='dns-prefetch' href='//cdn.jsdelivr.net' />
+    <link rel="alternate" type="application/rss+xml" title="Illinois Web Theme &raquo; Feed"
+        href="https://webtheme.illinois.edu/feed/" />
+    <link rel="alternate" type="application/rss+xml" title="Illinois Web Theme &raquo; Comments Feed"
+        href="https://webtheme.illinois.edu/comments/feed/" />
 
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="dns-prefetch" href="https://cdn.toolkit.illinois.edu" />
-    <link rel="icon" href="https://cdn.brand.illinois.edu/favicon.ico" />
-    <link type="text/css" rel="stylesheet" href="https://cdn.toolkit.illinois.edu/2.16/toolkit.css" />
-    <script src="https://cdn.toolkit.illinois.edu/2.16/toolkit.js"></script>
-    <title>Cookie Banner Example</title>
+    <link rel='stylesheet' id='toolkit-css' href='https://cdn.toolkit.illinois.edu/2.16/toolkit.css?ver=6.6.2'
+        media='all' />
+
+    <link rel='stylesheet' id='main-css-css'
+        href='https://webtheme.illinois.edu/wp-content/themes/uofi-2020/style.css?ver=240229-01525' media='all' />
+    <script src="https://cdn.toolkit.illinois.edu/2.16/toolkit.js?ver=6.6.2" id="toolkit-js"></script>
+    <script src="https://webtheme.illinois.edu/wp-includes/js/jquery/jquery.min.js?ver=3.7.1"
+        id="jquery-core-js"></script>
+    <script src="https://webtheme.illinois.edu/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1"
+        id="jquery-migrate-js"></script>
+    <script src="https://webtheme.illinois.edu/wp-content/themes/uofi-2020/js/main.js?ver=240229-01525"
+        id="main_js-js"></script>
+    <script src="https://webtheme.illinois.edu/wp-content/themes/uofi-2020/js/skipto.config.js"
+        id="skiptoconf-js"></script>
+    <script src="https://cdn.disability.illinois.edu/skipto.min.js" id="skipto-js"></script>
+
+    <link rel="icon" href="https://cdn.brand.illinois.edu/favicon.ico">
+
     <link rel="stylesheet" href="ila-cookie-banner.css" />
     <link rel="stylesheet" href="../ila-slideovers/ila-slideover.css" />
     <style>
@@ -55,6 +77,7 @@
 
 <body onload="openCookieB('ilaCookieBOne')">
     <il-page>
+
         <div class="cookieb-holder ila-cookieb_no-printing" role="alert">
             <div class="cookieb-holder-inner">
                 <div id="ilaCookieBOne" class="ila-cookieb ila-cookieb--closed">
@@ -79,12 +102,12 @@
                                     University of Illinois System Cookie Policy.</a>
                             </p>
                             <div class="ila-cookieb__actions">
-                                <button class="il-button ila-cookieb__button"
+                                <button type="button" class="il-button ila-cookieb__button"
                                     onclick="openSlideover('ilaSlideoverLeft')" aria-label="learn about cookies">
                                     About Cookies
                                 </button>
-                                <button class="il-button ila-cookieb__button" onclick="closeCookieB('ilaCookieBOne')"
-                                    aria-label="close cookie banner">
+                                <button type="button" class="il-button ila-cookieb__button"
+                                    onclick="closeCookieB('ilaCookieBOne')" aria-label="close cookie banner">
                                     Close this Notice
                                 </button>
                             </div>
@@ -93,16 +116,16 @@
                 </div>
             </div>
         </div>
-        <div id="ilaSlideoverLeft" 
-            class="ila-slideover ila-slideover--closed ila-slideover--left ila-cookieb_no-printing" 
-            role="dialog" aria-labelledby="ilaSlideoverLeftLabel" aria-modal="true">
+        <div id="ilaSlideoverLeft"
+            class="ila-slideover ila-slideover--closed ila-slideover--left ila-cookieb_no-printing" role="dialog"
+            aria-labelledby="ilaSlideoverLeftLabel" aria-modal="true">
             <div class="ila-slideover__overlay" onclick="closeSlideover('ilaSlideoverLeft')"></div>
             <div class="ila-slideover__slideover">
                 <div class="ila-slideover__header">
                     <h2 id="ilaSlideoverLeftLabel" class="ila-slideover__label">
                         Illinois
                     </h2>
-                    <button aria-label="close slideover" class="ila-slideover__close-button"
+                    <button type="button" aria-label="close slideover" class="ila-slideover__close-button"
                         onclick="closeSlideover('ilaSlideoverLeft')">
                         <div class="ila-slideover__close-icon il-icon" role="presentation">
                             cancel
@@ -145,7 +168,7 @@
                             the site will not work.</p>
                     </details>
                     <details>
-                        <summary  class="ila-cookieb__pointer_hover">
+                        <summary class="ila-cookieb__pointer_hover">
                             Performance Cookies - Always Active
                         </summary>
                         <p class="ila-cookieb__slide_small">
@@ -200,16 +223,17 @@
                     </details>
                 </div>
                 <div class="ila-cookieb__button-center-slideover">
-                    <button aria-label="close slideover" 
+                    <button type="button" aria-label="close slideover"
                         class="il-button ila-cookieb__button-close-slideover"
-                        onclick="closeSlideover('ilaSlideoverLeft')"
-                    >
+                        onclick="closeSlideover('ilaSlideoverLeft');">
                         Close
                     </button>
-            </div>
+                </div>
             </div>
         </div>
+
     </il-page>
+
     <script src="ila-cookie-banner.js"></script>
     <script src="../ila-slideovers/ila-slideover.js"></script>
 </body>

--- a/applications/ila-cookie-banner/ila-cookie-banner.html
+++ b/applications/ila-cookie-banner/ila-cookie-banner.html
@@ -97,9 +97,12 @@
                                 efforts. Click on “About Cookies” to learn more. By continuing to browse without
                                 changing your browser settings to block or delete Cookies, you agree to the storing of
                                 Cookies and related technologies on your device.
-
-                                <a target=_new href="https://www.vpaa.uillinois.edu/resources/cookies">
-                                    University of Illinois System Cookie Policy.</a>
+                                <br>
+                                <a class="ila-cookieb__popup-info" target=_new
+                                    href="https://www.vpaa.uillinois.edu/resources/cookies">
+                                    <strong>University of Illinois System Cookie Policy.</strong>
+                                    <span>Link opens in a new window</span>
+                                </a>
                             </p>
                             <div class="ila-cookieb__actions">
                                 <button type="button" class="il-button ila-cookieb__button"
@@ -150,8 +153,12 @@
                         intended.
                     </p>
                     <p class="ila-cookieb__slide_small">
-                        See the <a target=_new href="https://www.vpaa.uillinois.edu/resources/cookies">University of
-                            Illinois System Cookie Policy</a> for more information.
+                        See the
+                        <a class="ila-cookieb__popup-info-slideout" target=_new
+                            href="https://www.vpaa.uillinois.edu/resources/cookies">
+                            <strong>University of Illinois System Cookie Policy</strong>
+                            <span>Link opens in a new window</span>
+                        </a> for more information.
                     </p>
                     <details>
                         <summary class="ila-cookieb__pointer_hover">

--- a/applications/ila-cookie-banner/ila-cookie-banner.html
+++ b/applications/ila-cookie-banner/ila-cookie-banner.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="profile" href="https://gmpg.org/xfn/11">
-    <title>ILA CookieB</title>
+    <title>Cookie Banner Example</title>
     <meta name='robots' content='max-image-preview:large' />
     <link rel='dns-prefetch' href='//cdn.toolkit.illinois.edu' />
     <link rel='dns-prefetch' href='//cdn.disability.illinois.edu' />

--- a/applications/ila-cookie-banner/ila-cookie-banner.html
+++ b/applications/ila-cookie-banner/ila-cookie-banner.html
@@ -75,10 +75,10 @@
     </style>
 </head>
 
-<body onload="openCookieB('ilaCookieBOne', 'ilaCookieBFocusOnLoad', 'ilaCookieModal')">
+<body onload="openCookieB('ilaCookieBOne', 'ilaCookieBFocusOnLoad')">
     <il-page>
 
-        <div id="ilaCookieModal" aria-modal="true"></div>
+        <!-- <div id="ilaCookieModal" aria-modal="true"></div> -->
 
         <div class="cookieb-holder ila-cookieb_no-printing" role="alert">
             <div class="cookieb-holder-inner">
@@ -86,7 +86,7 @@
                     <div tabindex="0" id="ilaCookieBFocusOnLoad" class="ila-cookieb__cookieb"
                         aria-label="Cookie Banner">
                         <button type="button" class="ila-cookieb__close-button" aria-label="close cookie banner"
-                            onclick="closeCookieB('ilaCookieBOne', 'ilaCookieModal')">
+                            onclick="closeCookieB('ilaCookieBOne')">
                             <div class="ila-cookieb__close-icon il-icon" role="presentation">
                                 cancel
                             </div>
@@ -114,8 +114,7 @@
                                     About Cookies
                                 </button>
                                 <button type="button" class="il-button ila-cookieb__button"
-                                    onclick="closeCookieB('ilaCookieBOne', 'ilaCookieModal')"
-                                    aria-label="close cookie banner">
+                                    onclick="closeCookieB('ilaCookieBOne')" aria-label="close cookie banner">
                                     Close this Notice
                                 </button>
                             </div>

--- a/applications/ila-cookie-banner/ila-cookie-banner.js
+++ b/applications/ila-cookie-banner/ila-cookie-banner.js
@@ -1,4 +1,4 @@
-function openCookieB(cookiebId, focusOnLoad) {
+function openCookieB(cookiebId, focusOnLoad, modalID) {
     let cookieb = document.getElementById(cookiebId);
     cookieb.classList.remove('ila-cookieb--closed');
     cookieb.classList.add('ila-cookieb--open');
@@ -10,14 +10,24 @@ function openCookieB(cookiebId, focusOnLoad) {
     });
     cookieb.classList.add('ila-cookieb--first');
     manageAutoclose(cookiebId);
-    
+
+    document.body.classList.add('ila-cookieb-noscroll');
+
+    let modalIDvar = document.getElementById(modalID);
+    modalIDvar.classList.add('ila-cookieb-modal');
+
     document.getElementById(focusOnLoad).focus();
 }
 
-function closeCookieB(cookiebId) {
+function closeCookieB(cookiebId, modalID) {
     let cookieb = document.getElementById(cookiebId);
     cookieb.classList.remove('ila-cookieb--open');
     cookieb.classList.add('ila-cookieb--closed');
+
+    document.body.classList.remove('ila-cookieb-noscroll');
+
+    let modalIDvar = document.getElementById(modalID);
+    modalIDvar.classList.remove('ila-cookieb-modal');
 }
 
 function manageAutoclose(cookiebId) {

--- a/applications/ila-cookie-banner/ila-cookie-banner.js
+++ b/applications/ila-cookie-banner/ila-cookie-banner.js
@@ -1,4 +1,4 @@
-function openCookieB(cookiebId) {
+function openCookieB(cookiebId, focusOnLoad) {
     let cookieb = document.getElementById(cookiebId);
     cookieb.classList.remove('ila-cookieb--closed');
     cookieb.classList.add('ila-cookieb--open');
@@ -10,6 +10,8 @@ function openCookieB(cookiebId) {
     });
     cookieb.classList.add('ila-cookieb--first');
     manageAutoclose(cookiebId);
+    
+    document.getElementById(focusOnLoad).focus();
 }
 
 function closeCookieB(cookiebId) {

--- a/applications/ila-cookie-banner/ila-cookie-banner.js
+++ b/applications/ila-cookie-banner/ila-cookie-banner.js
@@ -1,4 +1,4 @@
-function openCookieB(cookiebId, focusOnLoad, modalID) {
+function openCookieB(cookiebId, focusOnLoad) {
     let cookieb = document.getElementById(cookiebId);
     cookieb.classList.remove('ila-cookieb--closed');
     cookieb.classList.add('ila-cookieb--open');
@@ -11,23 +11,27 @@ function openCookieB(cookiebId, focusOnLoad, modalID) {
     cookieb.classList.add('ila-cookieb--first');
     manageAutoclose(cookiebId);
 
-    document.body.classList.add('ila-cookieb-noscroll');
+    // Used to disable scroll on the page 
+    // document.body.classList.add('ila-cookieb-noscroll');
 
-    let modalIDvar = document.getElementById(modalID);
-    modalIDvar.classList.add('ila-cookieb-modal');
+    // Used to enable a modal background on the page
+    // let modalIDvar = document.getElementById(modalID);
+    // modalIDvar.classList.add('ila-cookieb-modal');
 
     document.getElementById(focusOnLoad).focus();
 }
 
-function closeCookieB(cookiebId, modalID) {
+function closeCookieB(cookiebId) {
     let cookieb = document.getElementById(cookiebId);
     cookieb.classList.remove('ila-cookieb--open');
     cookieb.classList.add('ila-cookieb--closed');
 
-    document.body.classList.remove('ila-cookieb-noscroll');
+    // Used to enable scroll on the page 
+    // document.body.classList.remove('ila-cookieb-noscroll');
 
-    let modalIDvar = document.getElementById(modalID);
-    modalIDvar.classList.remove('ila-cookieb-modal');
+    // Used to disable a modal background on the page
+    // let modalIDvar = document.getElementById(modalID);
+    // modalIDvar.classList.remove('ila-cookieb-modal');
 }
 
 function manageAutoclose(cookiebId) {

--- a/docs/Cookie-Banner.html
+++ b/docs/Cookie-Banner.html
@@ -1,18 +1,40 @@
-<!DOCTYPE html>
-
-<html lang="en" class="il-toolkit">
+<!doctype html>
+<html lang="en-US">
 
 <head>
-    <meta charset="utf-8" />
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="profile" href="https://gmpg.org/xfn/11">
     <title>Illinois Cookie Banner</title>
+    <meta name='robots' content='max-image-preview:large' />
+    <link rel='dns-prefetch' href='//cdn.toolkit.illinois.edu' />
+    <link rel='dns-prefetch' href='//cdn.disability.illinois.edu' />
+    <link rel='dns-prefetch' href='//stackpath.bootstrapcdn.com' />
+    <link rel='dns-prefetch' href='//kit.fontawesome.com' />
+    <link rel='dns-prefetch' href='//cdn.jsdelivr.net' />
+    <link rel="alternate" type="application/rss+xml" title="Illinois Web Theme &raquo; Feed"
+        href="https://webtheme.illinois.edu/feed/" />
+    <link rel="alternate" type="application/rss+xml" title="Illinois Web Theme &raquo; Comments Feed"
+        href="https://webtheme.illinois.edu/comments/feed/" />
 
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="dns-prefetch" href="https://cdn.toolkit.illinois.edu" />
-    <link rel="icon" href="https://cdn.brand.illinois.edu/favicon.ico" />
-    <link type="text/css" rel="stylesheet" href="https://cdn.toolkit.illinois.edu/2.16/toolkit.css" />
-    <script src="https://cdn.toolkit.illinois.edu/2.16/toolkit.js"></script>
-    <title>Cookie Banner Example</title>
+    <link rel='stylesheet' id='toolkit-css' href='https://cdn.toolkit.illinois.edu/2.16/toolkit.css?ver=6.6.2'
+        media='all' />
+
+    <link rel='stylesheet' id='main-css-css'
+        href='https://webtheme.illinois.edu/wp-content/themes/uofi-2020/style.css?ver=240229-01525' media='all' />
+    <script src="https://cdn.toolkit.illinois.edu/2.16/toolkit.js?ver=6.6.2" id="toolkit-js"></script>
+    <script src="https://webtheme.illinois.edu/wp-includes/js/jquery/jquery.min.js?ver=3.7.1"
+        id="jquery-core-js"></script>
+    <script src="https://webtheme.illinois.edu/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1"
+        id="jquery-migrate-js"></script>
+    <script src="https://webtheme.illinois.edu/wp-content/themes/uofi-2020/js/main.js?ver=240229-01525"
+        id="main_js-js"></script>
+    <script src="https://webtheme.illinois.edu/wp-content/themes/uofi-2020/js/skipto.config.js"
+        id="skiptoconf-js"></script>
+    <script src="https://cdn.disability.illinois.edu/skipto.min.js" id="skipto-js"></script>
+
+    <link rel="icon" href="https://cdn.brand.illinois.edu/favicon.ico">
+
     <link rel="stylesheet" href="css/ila-cookie-banner.css" />
     <link rel="stylesheet" href="css/ila-slideover.css" />
     <style>
@@ -111,11 +133,12 @@
                 <p>
                     The Cookie Banner is presented after loading this page
                 </p>
-                <button onclick="openSlideover('ilaSlideoverLeft')" aria-label="learn about cookies"
+                <button type="button" onclick="openSlideover('ilaSlideoverLeft')" aria-label="learn about cookies"
                     class="il-button ila-cookieb__button">
                     About Cookies
                 </button>
             </div>
+
             <div>
                 <h2>Link</h2>
                 <p>
@@ -150,12 +173,12 @@
                                     University of Illinois System Cookie Policy.</a>
                             </p>
                             <div class="ila-cookieb__actions">
-                                <button class="il-button ila-cookieb__button"
+                                <button type="button" class="il-button ila-cookieb__button"
                                     onclick="openSlideover('ilaSlideoverLeft')" aria-label="learn about cookies">
                                     About Cookies
                                 </button>
-                                <button class="il-button ila-cookieb__button" onclick="closeCookieB('ilaCookieBOne')"
-                                    aria-label="close cookie banner">
+                                <button type="button" class="il-button ila-cookieb__button"
+                                    onclick="closeCookieB('ilaCookieBOne')" aria-label="close cookie banner">
                                     Close this Notice
                                 </button>
                             </div>
@@ -164,16 +187,16 @@
                 </div>
             </div>
         </div>
-        <div id="ilaSlideoverLeft" 
-            class="ila-slideover ila-slideover--closed ila-slideover--left ila-cookieb_no-printing" 
-            role="dialog" aria-labelledby="ilaSlideoverLeftLabel" aria-modal="true">
+        <div id="ilaSlideoverLeft"
+            class="ila-slideover ila-slideover--closed ila-slideover--left ila-cookieb_no-printing" role="dialog"
+            aria-labelledby="ilaSlideoverLeftLabel" aria-modal="true">
             <div class="ila-slideover__overlay" onclick="closeSlideover('ilaSlideoverLeft')"></div>
             <div class="ila-slideover__slideover">
                 <div class="ila-slideover__header">
                     <h2 id="ilaSlideoverLeftLabel" class="ila-slideover__label">
                         Illinois
                     </h2>
-                    <button aria-label="close slideover" class="ila-slideover__close-button"
+                    <button type="button" aria-label="close slideover" class="ila-slideover__close-button"
                         onclick="closeSlideover('ilaSlideoverLeft')">
                         <div class="ila-slideover__close-icon il-icon" role="presentation">
                             cancel
@@ -216,7 +239,7 @@
                             the site will not work.</p>
                     </details>
                     <details>
-                        <summary  class="ila-cookieb__pointer_hover">
+                        <summary class="ila-cookieb__pointer_hover">
                             Performance Cookies - Always Active
                         </summary>
                         <p class="ila-cookieb__slide_small">
@@ -271,13 +294,12 @@
                     </details>
                 </div>
                 <div class="ila-cookieb__button-center-slideover">
-                    <button aria-label="close slideover" 
+                    <button type="button" aria-label="close slideover"
                         class="il-button ila-cookieb__button-close-slideover"
-                        onclick="closeSlideover('ilaSlideoverLeft');"
-                    >
+                        onclick="closeSlideover('ilaSlideoverLeft');">
                         Close
                     </button>
-            </div>
+                </div>
             </div>
         </div>
 

--- a/docs/Cookie-Banner.html
+++ b/docs/Cookie-Banner.html
@@ -126,7 +126,7 @@
 
         </div><!-- closes page wrapper -->
 
-        <div class="cookieb-holder" role="alert">
+        <div class="cookieb-holder ila-cookieb_no-printing" role="alert">
             <div class="cookieb-holder-inner">
                 <div id="ilaCookieBOne" class="ila-cookieb ila-cookieb--closed">
                     <div class="ila-cookieb__cookieb">
@@ -164,8 +164,9 @@
                 </div>
             </div>
         </div>
-        <div id="ilaSlideoverLeft" class="ila-slideover ila-slideover--closed ila-slideover--left" role="dialog"
-            aria-labelledby="ilaSlideoverLeftLabel" aria-modal="true">
+        <div id="ilaSlideoverLeft" 
+            class="ila-slideover ila-slideover--closed ila-slideover--left ila-cookieb_no-printing" 
+            role="dialog" aria-labelledby="ilaSlideoverLeftLabel" aria-modal="true">
             <div class="ila-slideover__overlay" onclick="closeSlideover('ilaSlideoverLeft')"></div>
             <div class="ila-slideover__slideover">
                 <div class="ila-slideover__header">
@@ -201,7 +202,9 @@
                             Illinois System Cookie Policy</a> for more information.
                     </p>
                     <details>
-                        <summary>Strictly Necessary Cookies - Always Active</summary>
+                        <summary class="ila-cookieb__pointer_hover">
+                            Strictly Necessary Cookies - Always Active
+                        </summary>
                         <p class="ila-cookieb__slide_small">
                             Strictly Necessary Cookies are first-party Cookies that are necessary for the website to
                             function. They can be either permanent or temporary and are usually only set in response to
@@ -213,7 +216,9 @@
                             the site will not work.</p>
                     </details>
                     <details>
-                        <summary>Performance Cookies - Always Active</summary>
+                        <summary  class="ila-cookieb__pointer_hover">
+                            Performance Cookies - Always Active
+                        </summary>
                         <p class="ila-cookieb__slide_small">
                             Performance Cookies allow us to count visits and traffic sources so we can measure and
                             improve the performance and effectiveness of University websites. Performance Cookies also
@@ -230,7 +235,9 @@
                             work.</p>
                     </details>
                     <details>
-                        <summary>Functional Cookies - Always Active</summary>
+                        <summary class="ila-cookieb__pointer_hover">
+                            Functional Cookies - Always Active
+                        </summary>
                         <p class="ila-cookieb__slide_small">
                             Functional Cookies enhance the performance and functionality of our websites but are
                             non-essential to their use. These permanent Cookies allow our website to remember
@@ -241,7 +248,9 @@
                             Cookies, some or all of these services may not function properly.</p>
                     </details>
                     <details>
-                        <summary>Targeting Cookies - Always Active</summary>
+                        <summary class="ila-cookieb__pointer_hover">
+                            Targeting Cookies - Always Active
+                        </summary>
                         <p class="ila-cookieb__slide_small">
                             Targeting Cookies are used to deliver content tailored to your interests and may be
                             temporary or permanent. They may also be first-party or third-party Cookies. Targeting
@@ -259,7 +268,16 @@
                             that you have provided to them or that they have collected from your use of their services.
                             If you set your browser to block or delete Cookies, you will still see advertisements, but
                             they will be less targeted to your interests.</p>
+                    </details>
                 </div>
+                <div class="ila-cookieb__button-center-slideover">
+                    <button aria-label="close slideover" 
+                        class="il-button ila-cookieb__button-close-slideover"
+                        onclick="closeSlideover('ilaSlideoverLeft');"
+                    >
+                        Close
+                    </button>
+            </div>
             </div>
         </div>
 

--- a/docs/Cookie-Banner.html
+++ b/docs/Cookie-Banner.html
@@ -75,7 +75,7 @@
     </style>
 </head>
 
-<body onload="openCookieB('ilaCookieBOne', 'ilaCookieBFocusOnLoad', 'ilaCookieModal')">
+<body onload="openCookieB('ilaCookieBOne', 'ilaCookieBFocusOnLoad')">
     <header id="masthead" class="site-header">
         <div class="masthead_inner d-flex justify-content-between align-items-stretch">
             <div class="il-header-wrapper flex-grow-1">
@@ -149,7 +149,7 @@
 
         </div><!-- closes page wrapper -->
 
-        <div id="ilaCookieModal" aria-modal="true"></div>
+        <!-- <div id="ilaCookieModal" aria-modal="true"></div> -->
 
         <div class="cookieb-holder ila-cookieb_no-printing" role="alert">
             <div class="cookieb-holder-inner">
@@ -157,7 +157,7 @@
                     <div tabindex="0" id="ilaCookieBFocusOnLoad" class="ila-cookieb__cookieb"
                         aria-label="Cookie Banner">
                         <button type="button" class="ila-cookieb__close-button" aria-label="close cookie banner"
-                            onclick="closeCookieB('ilaCookieBOne', 'ilaCookieModal')">
+                            onclick="closeCookieB('ilaCookieBOne')">
                             <div class="ila-cookieb__close-icon il-icon" role="presentation">
                                 cancel
                             </div>
@@ -185,8 +185,7 @@
                                     About Cookies
                                 </button>
                                 <button type="button" class="il-button ila-cookieb__button"
-                                    onclick="closeCookieB('ilaCookieBOne', 'ilaCookieModal')"
-                                    aria-label="close cookie banner">
+                                    onclick="closeCookieB('ilaCookieBOne')" aria-label="close cookie banner">
                                     Close this Notice
                                 </button>
                             </div>

--- a/docs/Cookie-Banner.html
+++ b/docs/Cookie-Banner.html
@@ -168,9 +168,12 @@
                                 efforts. Click on “About Cookies” to learn more. By continuing to browse without
                                 changing your browser settings to block or delete Cookies, you agree to the storing of
                                 Cookies and related technologies on your device.
-
-                                <a target=_new href="https://www.vpaa.uillinois.edu/resources/cookies">
-                                    University of Illinois System Cookie Policy.</a>
+                                <br>
+                                <a class="ila-cookieb__popup-info" target=_new
+                                    href="https://www.vpaa.uillinois.edu/resources/cookies">
+                                    <strong>University of Illinois System Cookie Policy.</strong>
+                                    <span>Link opens in a new window</span>
+                                </a>
                             </p>
                             <div class="ila-cookieb__actions">
                                 <button type="button" class="il-button ila-cookieb__button"
@@ -221,8 +224,12 @@
                         intended.
                     </p>
                     <p class="ila-cookieb__slide_small">
-                        See the <a target=_new href="https://www.vpaa.uillinois.edu/resources/cookies">University of
-                            Illinois System Cookie Policy</a> for more information.
+                        See the
+                        <a class="ila-cookieb__popup-info-slideout" target=_new
+                            href="https://www.vpaa.uillinois.edu/resources/cookies">
+                            <strong>University of Illinois System Cookie Policy</strong>
+                            <span>Link opens in a new window</span>
+                        </a> for more information.
                     </p>
                     <details>
                         <summary class="ila-cookieb__pointer_hover">

--- a/docs/Cookie-Banner.html
+++ b/docs/Cookie-Banner.html
@@ -149,7 +149,7 @@
 
         </div><!-- closes page wrapper -->
 
-        <div id="ilaCookieModal"></div>
+        <div id="ilaCookieModal" aria-modal="true"></div>
 
         <div class="cookieb-holder ila-cookieb_no-printing" role="alert">
             <div class="cookieb-holder-inner">
@@ -180,7 +180,8 @@
                             </p>
                             <div class="ila-cookieb__actions">
                                 <button type="button" class="il-button ila-cookieb__button"
-                                    onclick="openSlideover('ilaSlideoverLeft')" aria-label="learn about cookies">
+                                    onclick="openSlideover('ilaSlideoverLeft')"
+                                    aria-label="learn about cookies - opens modal dialogue">
                                     About Cookies
                                 </button>
                                 <button type="button" class="il-button ila-cookieb__button"
@@ -201,9 +202,9 @@
             <div class="ila-slideover__slideover">
                 <div class="ila-slideover__header">
                     <h2 id="ilaSlideoverLeftLabel" class="ila-slideover__label">
-                        Illinois
+                        University of Illinois - Cookie Information
                     </h2>
-                    <button type="button" aria-label="close slideover" class="ila-slideover__close-button"
+                    <button type="button" aria-label="close" class="ila-slideover__close-button"
                         onclick="closeSlideover('ilaSlideoverLeft')">
                         <div class="ila-slideover__close-icon il-icon" role="presentation">
                             cancel

--- a/docs/Cookie-Banner.html
+++ b/docs/Cookie-Banner.html
@@ -75,7 +75,7 @@
     </style>
 </head>
 
-<body onload="openCookieB('ilaCookieBOne', 'ilaCookieBFocusOnLoad')">
+<body onload="openCookieB('ilaCookieBOne', 'ilaCookieBFocusOnLoad', 'ilaCookieModal')">
     <header id="masthead" class="site-header">
         <div class="masthead_inner d-flex justify-content-between align-items-stretch">
             <div class="il-header-wrapper flex-grow-1">
@@ -149,13 +149,15 @@
 
         </div><!-- closes page wrapper -->
 
+        <div id="ilaCookieModal"></div>
+
         <div class="cookieb-holder ila-cookieb_no-printing" role="alert">
             <div class="cookieb-holder-inner">
                 <div id="ilaCookieBOne" class="ila-cookieb ila-cookieb--closed">
                     <div tabindex="0" id="ilaCookieBFocusOnLoad" class="ila-cookieb__cookieb"
                         aria-label="Cookie Banner">
                         <button type="button" class="ila-cookieb__close-button" aria-label="close cookie banner"
-                            onclick="closeCookieB('ilaCookieBOne')">
+                            onclick="closeCookieB('ilaCookieBOne', 'ilaCookieModal')">
                             <div class="ila-cookieb__close-icon il-icon" role="presentation">
                                 cancel
                             </div>
@@ -182,7 +184,8 @@
                                     About Cookies
                                 </button>
                                 <button type="button" class="il-button ila-cookieb__button"
-                                    onclick="closeCookieB('ilaCookieBOne')" aria-label="close cookie banner">
+                                    onclick="closeCookieB('ilaCookieBOne', 'ilaCookieModal')"
+                                    aria-label="close cookie banner">
                                     Close this Notice
                                 </button>
                             </div>

--- a/docs/Cookie-Banner.html
+++ b/docs/Cookie-Banner.html
@@ -75,7 +75,7 @@
     </style>
 </head>
 
-<body onload="openCookieB('ilaCookieBOne')">
+<body onload="openCookieB('ilaCookieBOne', 'ilaCookieBFocusOnLoad')">
     <header id="masthead" class="site-header">
         <div class="masthead_inner d-flex justify-content-between align-items-stretch">
             <div class="il-header-wrapper flex-grow-1">
@@ -152,7 +152,8 @@
         <div class="cookieb-holder ila-cookieb_no-printing" role="alert">
             <div class="cookieb-holder-inner">
                 <div id="ilaCookieBOne" class="ila-cookieb ila-cookieb--closed">
-                    <div class="ila-cookieb__cookieb">
+                    <div tabindex="0" id="ilaCookieBFocusOnLoad" class="ila-cookieb__cookieb"
+                        aria-label="Cookie Banner">
                         <button type="button" class="ila-cookieb__close-button" aria-label="close cookie banner"
                             onclick="closeCookieB('ilaCookieBOne')">
                             <div class="ila-cookieb__close-icon il-icon" role="presentation">


### PR DESCRIPTION
Closes #133 

Updates: 

- Slideout wider on smaller screens 
- Add space above Banner Heading 
- Make Details in Slideout change pointer for clickable area on hover 
- Add Close button to the bottom of the Slideout 
- Hide Cookie Banner and Slideout when printing 
- Mirror changes between the two HTML files 
- Changes for V3 instead of V2 
- Add missing `type` to `button` tags 
- Hover and Focus both change button appearance 
- Added popup to links in the Cookie Banner and the About Slideout 
- Added `active` options to the CSS in addition to `hover` and `focus` 
- Various reformatting for readability 
- Focus on the Cookie Banner on Load 
