### PR TITLE
Add Example CSS to support UIC and UIS using the Cookie Banner

### DIFF
--- a/applications/ila-cookie-banner/ila-cookie-banner.css
+++ b/applications/ila-cookie-banner/ila-cookie-banner.css
@@ -2,9 +2,37 @@
     --ila-cookieb-margin: .25rem;
     --ila-cookieb-padding-x: 1rem;
     --ila-cookieb-padding-y: .3rem;
-    --ila-cookieb-background-blue: var(--il-blue);
     --ila-cookieb-font-white: #ffffff;
-    --ila-cookieb-hover-orange: var(--il-orange);
+    /**** UIUC Colors ****/
+    --ila-cookieb-main: var(--il-blue);
+    --ila-cookieb-accent: var(--il-orange);
+    --ila-cookieb-hover-button-font: #ffffff;
+    --ila-cookieb-hover-text-font: #ffffff;
+    --il-focused-link-color: var(--il-orange);
+    --ila-cookieb-line-color: var(--il-orange);
+    --ila-cookieb-focused-link-color: var(--il-focused-link-color);
+    --ila-cookieb-slideout-focused-link-color: var(--il-focused-link-color);
+    --ila-cookieb-link-color: var(--il-link-color);
+    /**** UIS Colors ****/
+    /* --ila-cookieb-main: #003366;
+    --ila-cookieb-accent: #c8b18b;
+    --ila-cookieb-hover-button-font: #003366;
+    --ila-cookieb-hover-text-font: var(--ila-cookieb-font-white);
+    --il-focused-link-color: #555555;
+    --ila-cookieb-line-color: #c8b18b;
+    --ila-cookieb-focused-link-color: #c8b18b;
+    --ila-cookieb-slideout-focused-link-color: #555555;
+    --ila-cookieb-link-color: #003366; */
+    /**** UIC Colors ****/
+    /* --ila-cookieb-main: #001E62;
+    --ila-cookieb-accent: #FFBF3F;
+    --ila-cookieb-hover-button-font: #001E62;
+    --ila-cookieb-hover-text-font: var(--ila-cookieb-font-white);
+    --il-focused-link-color: #333333;
+    --ila-cookieb-line-color: #FFBF3F;
+    --ila-cookieb-focused-link-color: #FFBF3F;
+    --ila-cookieb-slideout-focused-link-color: #333333;
+    --ila-cookieb-link-color: #001E62; */
 }
 
 .cookieb-holder {
@@ -58,8 +86,8 @@
 .ila-cookieb__button-close-slideover:focus,
 .ila-cookieb__button-close-slideover:active {
     transition: background-color 0.3s;
-    background-color: var(--ila-cookieb-hover-orange);
-    color: white;
+    background-color: var(--ila-cookieb-accent);
+    color: var(--ila-cookieb-hover-button-font);
 }
 
 .ila-cookieb__close-button {
@@ -79,14 +107,15 @@
 .ila-cookieb__close-button:focus,
 .ila-cookieb__close-button:active {
     transition: background-color 0.3s;
-    background-color: var(--ila-cookieb-hover-orange);
-    color: white;
+    background-color: var(--ila-cookieb-accent);
+    color: var(--ila-cookieb-hover-button-font);
 }
 
 .ila-cookieb__button:hover,
 .ila-cookieb__button:focus,
 .ila-cookieb__button:active {
-    background-color: var(--ila-cookieb-hover-orange);
+    background-color: var(--ila-cookieb-accent);
+    color: var(--ila-cookieb-hover-button-font);
 }
 
 .ila-cookieb__close-icon {
@@ -153,7 +182,7 @@
 
 .ila-cookieb__cookieb {
     color: var(--ila-cookieb-font-white);
-    background-color: var(--ila-cookieb-background-blue);
+    background-color: var(--ila-cookieb-main);
 }
 
 .ila-cookieb__cookieb a {
@@ -172,6 +201,18 @@
     display: none;
 }
 
+.ila-cookieb__popup-info-link:hover,
+.ila-cookieb__popup-info-link:focus,
+.ila-cookieb__popup-info-link:active {
+    color: var(--ila-cookieb-focused-link-color);
+}
+
+.ila-cookieb__popup-info-slideout-link:hover,
+.ila-cookieb__popup-info-slideout-link:focus,
+.ila-cookieb__popup-info-slideout-link:active {
+    color: var(--ila-cookieb-slideout-focused-link-color);
+}
+
 .ila-cookieb__popup-info:hover span,
 .ila-cookieb__popup-info:focus span,
 .ila-cookieb__popup-info:active span {
@@ -180,10 +221,10 @@
     bottom: 2.5rem;
     left: 10rem;
     padding: 1rem;
-    background-color: var(--il-blue);
-    color: #ffffff;
+    background-color: var(--ila-cookieb-main);
+    color: var(--ila-cookieb-hover-text-font);
     border-style: solid;
-    border-color: var(--il-orange);
+    border-color: var(--ila-cookieb-accent);
 }
 
 @media (max-width: 1030px) {
@@ -207,10 +248,10 @@
     bottom: auto;
     left: 10rem;
     padding: 1rem;
-    background-color: var(--il-blue);
-    color: #ffffff;
+    background-color: var(--ila-cookieb-main);
+    color: var(--ila-cookieb-hover-text-font);
     border-style: solid;
-    border-color: var(--il-orange);
+    border-color: var(--ila-cookieb-accent);
 }
 
 @media (max-width: 1030px) {
@@ -220,6 +261,10 @@
     .ila-cookieb__popup-info-slideout:active span {
         bottom: auto;
     }
+}
+
+.ila-cookieb-slideover__header {
+    border-color: var(--ila-cookieb-line-color) !important;
 }
 
 /* Used to enable or disable scroll on the page */
@@ -239,4 +284,3 @@
     left: 0;
     background-color: #24242496;
 } */
- 

--- a/applications/ila-cookie-banner/ila-cookie-banner.html
+++ b/applications/ila-cookie-banner/ila-cookie-banner.html
@@ -48,7 +48,7 @@
 
         a {
             transition: color 0.3s;
-            color: var(--il-link-color);
+            color: var(--ila-cookieb-link-color);
             text-decoration: underline;
         }
 
@@ -101,7 +101,7 @@
                                 changing your browser settings to block or delete Cookies, you agree to the storing of
                                 Cookies and related technologies on your device.
                                 <br>
-                                <a class="ila-cookieb__popup-info" target=_new
+                                <a class="ila-cookieb__popup-info-link ila-cookieb__popup-info" target=_new
                                     href="https://www.vpaa.uillinois.edu/resources/cookies">
                                     <strong>University of Illinois System Cookie Policy.</strong>
                                     <span>Link opens in a new window</span>
@@ -128,7 +128,7 @@
             aria-labelledby="ilaSlideoverLeftLabel" aria-modal="true">
             <div class="ila-slideover__overlay" onclick="closeSlideover('ilaSlideoverLeft')"></div>
             <div class="ila-slideover__slideover">
-                <div class="ila-slideover__header">
+                <div class="ila-slideover__header ila-cookieb-slideover__header">
                     <h2 id="ilaSlideoverLeftLabel" class="ila-slideover__label">
                         University of Illinois - Cookie Information
                     </h2>
@@ -158,7 +158,7 @@
                     </p>
                     <p class="ila-cookieb__slide_small">
                         See the
-                        <a class="ila-cookieb__popup-info-slideout" target=_new
+                        <a class="ila-cookieb__popup-info-slideout-link ila-cookieb__popup-info-slideout" target=_new
                             href="https://www.vpaa.uillinois.edu/resources/cookies">
                             <strong>University of Illinois System Cookie Policy</strong>
                             <span>Link opens in a new window</span>

--- a/docs/Cookie-Banner.html
+++ b/docs/Cookie-Banner.html
@@ -48,7 +48,7 @@
 
         a {
             transition: color 0.3s;
-            color: var(--il-link-color);
+            color: var(--ila-cookieb-link-color);
             text-decoration: underline;
         }
 
@@ -172,7 +172,7 @@
                                 changing your browser settings to block or delete Cookies, you agree to the storing of
                                 Cookies and related technologies on your device.
                                 <br>
-                                <a class="ila-cookieb__popup-info" target=_new
+                                <a class="ila-cookieb__popup-info-link ila-cookieb__popup-info" target=_new
                                     href="https://www.vpaa.uillinois.edu/resources/cookies">
                                     <strong>University of Illinois System Cookie Policy.</strong>
                                     <span>Link opens in a new window</span>
@@ -199,7 +199,7 @@
             aria-labelledby="ilaSlideoverLeftLabel" aria-modal="true">
             <div class="ila-slideover__overlay" onclick="closeSlideover('ilaSlideoverLeft')"></div>
             <div class="ila-slideover__slideover">
-                <div class="ila-slideover__header">
+                <div class="ila-slideover__header ila-cookieb-slideover__header">
                     <h2 id="ilaSlideoverLeftLabel" class="ila-slideover__label">
                         University of Illinois - Cookie Information
                     </h2>
@@ -229,7 +229,7 @@
                     </p>
                     <p class="ila-cookieb__slide_small">
                         See the
-                        <a class="ila-cookieb__popup-info-slideout" target=_new
+                        <a class="ila-cookieb__popup-info-slideout-link ila-cookieb__popup-info-slideout" target=_new
                             href="https://www.vpaa.uillinois.edu/resources/cookies">
                             <strong>University of Illinois System Cookie Policy</strong>
                             <span>Link opens in a new window</span>


### PR DESCRIPTION
Closes #138

Campus Coloring Updates:
- Added sections in CSS for UIUC, UIS, and UIC coloring with variables
- Added and modified CSS classes to use the new coloring variables
- Updated HTML to use new CSS classes and variables

For testing:
To change colors for different Campuses, comment out the appropriate section desired under the `:root` class in the Cookie Banner CSS file. This is located at: https://github.com/app-illinois/Design-Resources/blob/feature/issue138/applications/ila-cookie-banner/ila-cookie-banner.css#L1 