### PR TITLE
Restore for demo purposes

### DIFF
--- a/applications/ila-cookie-banner/ila-cookie-banner.js
+++ b/applications/ila-cookie-banner/ila-cookie-banner.js
@@ -1,6 +1,6 @@
 
 // TODO: Update this to a load-balanced resilient (CDN) path:
-let cookie_banner_root_url = 'https://onetrust.techservices.illinois.edu/0.1.0';
+let cookie_banner_root_url = 'https://app-illinois.github.io/Design-Resources';
 // For local testing purposes, uncomment the line below and comment out the line above:
 //let cookie_banner_root_url = '.';
 let get_url = cookie_banner_root_url;


### PR DESCRIPTION
Restore the root URL to demo-only for now, while folks are checking out the demo site today.