### PR TITLE
Fixes for 192

### DIFF
--- a/applications/ila-cookie-banner/CONTRIBUTING.md
+++ b/applications/ila-cookie-banner/CONTRIBUTING.md
@@ -22,5 +22,6 @@ python -m http.server 8888
 
 Once this mini web server is running, the pages can be tested by visiting `http://localhost:8888`.
 
-> Standard disclaimer: the Python mini web server is not acceptable for any production hosting.
+To test the cookie banner, use the URL `http://localhost:8888/docs/Cookie-Banner.html`.
 
+> Standard disclaimer: the Python mini web server is not acceptable for any production hosting.

--- a/applications/ila-cookie-banner/ila-cookie-banner-content.part.html
+++ b/applications/ila-cookie-banner/ila-cookie-banner-content.part.html
@@ -48,7 +48,7 @@
     <div class="ila-slideover__overlay" onclick="closeSlideover('ilaCookieSlideover')"></div>
     <div class="ila-slideover__slideover">
         <div class="ila-slideover__header ila-cookieb-slideover__header">
-            <h2 id="ilaCookieSlideoverLabel" class="ila-slideover__label" aria-label="University of Illinois - Cookie Information">
+            <h2 tabindex="0" id="ilaCookieSlideoverLabel" class="ila-slideover__label" aria-label="University of Illinois - Cookie Information">
                 University of Illinois - Cookie Information
             </h2>
         </div>

--- a/applications/ila-cookie-banner/ila-cookie-banner-content.part.html
+++ b/applications/ila-cookie-banner/ila-cookie-banner-content.part.html
@@ -71,7 +71,7 @@
             </p>
             <p class="ila-cookieb__slide_small">
                 See the
-                <a id="system-cookie-policy-link" class="ila-cookieb__popup-info-slideout-link ila-cookieb__popup-info-slideout" target=_new
+                <a id="system-cookie-policy-link" class="ila-cookieb__popup-info-slideout-link ila-cookieb__popup-info-slideout ila-cookieb__small-font-link" target=_new
                     href="https://www.vpaa.uillinois.edu/resources/cookies">
                     <strong>University of Illinois System Cookie Policy</strong>
                     <span>Link opens in a new window</span>

--- a/applications/ila-cookie-banner/ila-cookie-banner-content.part.html
+++ b/applications/ila-cookie-banner/ila-cookie-banner-content.part.html
@@ -43,20 +43,14 @@
     </div>
 </div>
 <div id="ilaCookieSlideover"
-    class="ila-slideover ila-slideover--closed ila-slideover--left ila-cookieb_no-printing" role="dialog"
+    class="ila-slideover ila-slideover--closed ila-slideover--left ila-cookieb_no-printing" role="alertdialog"
     aria-labelledby="ilaCookieSlideoverLabel" aria-modal="true">
     <div class="ila-slideover__overlay" onclick="closeSlideover('ilaCookieSlideover')"></div>
     <div class="ila-slideover__slideover">
         <div class="ila-slideover__header ila-cookieb-slideover__header">
-            <h2 id="ilaCookieSlideoverLabel" class="ila-slideover__label">
+            <h2 id="ilaCookieSlideoverLabel" class="ila-slideover__label" aria-label="University of Illinois - Cookie Information">
                 University of Illinois - Cookie Information
             </h2>
-            <button type="button" aria-label="close cookie notice" class="ila-slideover__close-button"
-                onclick="closeSlideover('ilaCookieSlideover')">
-                <div class="ila-slideover__close-icon" role="presentation">
-                    <strong>X</strong>
-                </div>
-            </button>
         </div>
         <div class="ila-slideover__content ila-cookieb_slide_content">
             <h3>About Cookies</h3>
@@ -77,7 +71,7 @@
             </p>
             <p class="ila-cookieb__slide_small">
                 See the
-                <a class="ila-cookieb__popup-info-slideout-link ila-cookieb__popup-info-slideout" target=_new
+                <a id="system-cookie-policy-link" class="ila-cookieb__popup-info-slideout-link ila-cookieb__popup-info-slideout" target=_new
                     href="https://www.vpaa.uillinois.edu/resources/cookies">
                     <strong>University of Illinois System Cookie Policy</strong>
                     <span>Link opens in a new window</span>

--- a/applications/ila-cookie-banner/ila-cookie-banner-content.part.html
+++ b/applications/ila-cookie-banner/ila-cookie-banner-content.part.html
@@ -43,7 +43,7 @@
     </div>
 </div>
 <div id="ilaCookieSlideover"
-    class="ila-slideover ila-slideover--closed ila-slideover--left ila-cookieb_no-printing" role="alertdialog"
+    class="ila-slideover ila-slideover--closed ila-slideover--left ila-cookieb_no-printing" role="dialog"
     aria-labelledby="ilaCookieSlideoverLabel" aria-modal="true">
     <div class="ila-slideover__overlay" onclick="closeSlideover('ilaCookieSlideover')"></div>
     <div class="ila-slideover__slideover">

--- a/applications/ila-cookie-banner/ila-cookie-banner-content.part.html
+++ b/applications/ila-cookie-banner/ila-cookie-banner-content.part.html
@@ -48,7 +48,7 @@
     <div class="ila-slideover__overlay" onclick="closeSlideover('ilaCookieSlideover')"></div>
     <div class="ila-slideover__slideover">
         <div class="ila-slideover__header ila-cookieb-slideover__header">
-            <h2 tabindex="0" id="ilaCookieSlideoverLabel" class="ila-slideover__label" aria-label="University of Illinois - Cookie Information">
+            <h2 id="ilaCookieSlideoverLabel" class="ila-slideover__label" aria-label="University of Illinois - Cookie Information">
                 University of Illinois - Cookie Information
             </h2>
         </div>

--- a/applications/ila-cookie-banner/ila-cookie-banner.css
+++ b/applications/ila-cookie-banner/ila-cookie-banner.css
@@ -10,6 +10,8 @@
     --ila-cookieb-button-background-color: #ffffff; /* white */
     --ila-cookieb-font-sans: "Source Sans Pro", sans-serif;
     --ila-cookieb-button-foreground-color: #13294b; /* from --il-blue */
+    /* https://brand.illinois.edu/visual-identity/color */
+    --ila-cookieb-small-link-focus: #c84113; /* from -il-altgeld */
 }
 
 body {
@@ -144,6 +146,12 @@ body {
 
 .ila-cookieb__pointer_hover {
     cursor: pointer;
+}
+
+.ila-cookieb__small-font-link:hover,
+.ila-cookieb__small-font-link:focus,
+.ila-cookieb__small-font-link:active {
+    color: var(--ila-cookieb-small-link-focus);
 }
 
 /* allow buttons to slide underneath text on thin screens */

--- a/applications/ila-cookie-banner/ila-cookie-banner.js
+++ b/applications/ila-cookie-banner/ila-cookie-banner.js
@@ -56,6 +56,16 @@ function closeCookieB(cookiebId) {
     if(h1tag) { h1tag.focus(); }
 }
 
+// function focusOnHeader() {
+//     let header_tag = document.getElementById('system-cookie-policy-link');
+//     if(header_tag) { header_tag.focus(); }
+// }
+
+// function openCookieSlideover(cookiebId) {
+//     openSlideover(cookiebId);
+//     focusOnHeader();
+// }
+
 function manageAutoclose(cookiebId) {
     /* setTimeout(() => closeCookieB(cookiebId), 8000); */
 }

--- a/applications/ila-cookie-banner/ila-cookie-banner.js
+++ b/applications/ila-cookie-banner/ila-cookie-banner.js
@@ -56,16 +56,6 @@ function closeCookieB(cookiebId) {
     if(h1tag) { h1tag.focus(); }
 }
 
-// function focusOnHeader() {
-//     let header_tag = document.getElementById('system-cookie-policy-link');
-//     if(header_tag) { header_tag.focus(); }
-// }
-
-// function openCookieSlideover(cookiebId) {
-//     openSlideover(cookiebId);
-//     focusOnHeader();
-// }
-
 function manageAutoclose(cookiebId) {
     /* setTimeout(() => closeCookieB(cookiebId), 8000); */
 }

--- a/applications/ila-cookie-banner/ila-cookie-uiuc-colors.css
+++ b/applications/ila-cookie-banner/ila-cookie-uiuc-colors.css
@@ -7,6 +7,6 @@
     --il-focused-link-color: #FF5F05;
     --ila-cookieb-line-color: #FF5F05;
     --ila-cookieb-focused-link-color: #FF5F05;
-    --ila-cookieb-slideout-focused-link-color: #FF5F05;
+    --ila-cookieb-slideout-focused-link-color: #c84113;
     --ila-cookieb-link-color: #1D58A7;
 }

--- a/applications/ila-slideovers/ila-slideover.css
+++ b/applications/ila-slideovers/ila-slideover.css
@@ -67,6 +67,7 @@
 
 .ila-slideover__label {
   margin: 0;
+  padding: .2em 0;
 }
 
 .ila-slideover__close-button {

--- a/applications/ila-slideovers/ila-slideover.js
+++ b/applications/ila-slideovers/ila-slideover.js
@@ -55,12 +55,11 @@ aria.Utils.focusLastDescendant = function (element) {
  *  true if element is focused.
  */
 aria.Utils.attemptFocus = function (element) {
-    console.log('Attempting to focus on element:', element);
     if (!aria.Utils.isFocusable(element)) {
-        console.warn(
-            'Attempted to focus on an element that is not focusable.',
-            element
-        );
+        // console.debug(
+        //     'Attempted to focus on an element that is not focusable.',
+        //     element
+        // );
         return false;
     }
 
@@ -72,7 +71,7 @@ aria.Utils.attemptFocus = function (element) {
         console.warn('Error focusing element:', e);
     }
     aria.Utils.IgnoreUtilFocusChanges = false;
-    console.debug('Focused element:', element);
+    // console.debug('Focused element:', element);
     return document.activeElement === element;
 }; // end attemptFocus
 

--- a/applications/ila-slideovers/ila-slideover.js
+++ b/applications/ila-slideovers/ila-slideover.js
@@ -52,27 +52,6 @@ aria.Utils.focusLastDescendant = function (element) {
   }; // end focusLastDescendant
 
 /**
- * @description Set focus on descendant nodes until the last focusable element is
- *       found.
- * @param element
- *          DOM node for which to find the last focusable descendant.
- * @returns {boolean}
- *  true if a focusable element is found and focus is set.
- */
-aria.Utils.focusLastDescendant = function (element) {
-    for (var i = element.childNodes.length; i > 0; i--) {
-        var child = element.childNodes[i];
-        if (
-            aria.Utils.attemptFocus(child) ||
-            aria.Utils.focusLastDescendant(child)
-        ) {
-            return true;
-        }
-    }
-    return false;
-}; // end focusFirstDescendant
-
-/**
  * @description Set Attempt to set focus on the current node.
  * @param element
  *          The node to attempt to focus on.

--- a/applications/ila-slideovers/ila-slideover.js
+++ b/applications/ila-slideovers/ila-slideover.js
@@ -8,9 +8,8 @@ aria.Utils = aria.Utils || {};
 window.openSlideover = async function (dialogId) {
     await new aria.Dialog(dialogId);
     // Put focus on a button.
-    let button_tag = document.querySelector(`#${dialogId} button`);
-    console.log(button_tag);
-    aria.Utils.attemptFocus(button_tag);
+    let title_tag = document.querySelector(`.ila-slideover__label`);
+    aria.Utils.attemptFocus(title_tag);
 };
 
 window.closeSlideover = function () {
@@ -277,6 +276,9 @@ aria.Utils.isFocusable = function (element) {
         case 'TEXTAREA':
             return true;
         default:
+            if (element.tabIndex >= 0) {
+                return true;
+            }
             return false;
     }
 };

--- a/applications/ila-slideovers/ila-slideover.js
+++ b/applications/ila-slideovers/ila-slideover.js
@@ -7,6 +7,10 @@ aria.Utils = aria.Utils || {};
 
 window.openSlideover = function (dialogId) {
     new aria.Dialog(dialogId);
+    // Put focus on a button.
+    let button_tag = document.querySelector(`#${dialogId} button`);
+    console.log(button_tag);
+    aria.Utils.attemptFocus(button_tag);
 };
 
 window.closeSlideover = function () {
@@ -55,7 +59,12 @@ aria.Utils.focusLastDescendant = function (element) {
  *  true if element is focused.
  */
 aria.Utils.attemptFocus = function (element) {
+    console.debug('Attempting to focus on element:', element);
     if (!aria.Utils.isFocusable(element)) {
+        console.warn(
+            'Attempted to focus on an element that is not focusable.',
+            element
+        );
         return false;
     }
 
@@ -64,8 +73,10 @@ aria.Utils.attemptFocus = function (element) {
         element.focus();
     } catch (e) {
         // continue regardless of error
+        console.warn('Error focusing element:', e);
     }
     aria.Utils.IgnoreUtilFocusChanges = false;
+    console.debug('Focused element:', element);
     return document.activeElement === element;
 }; // end attemptFocus
 

--- a/applications/ila-slideovers/ila-slideover.js
+++ b/applications/ila-slideovers/ila-slideover.js
@@ -5,11 +5,8 @@ var aria = aria || {};
 
 aria.Utils = aria.Utils || {};
 
-window.openSlideover = async function (dialogId) {
-    await new aria.Dialog(dialogId);
-    // Put focus on a button.
-    let title_tag = document.querySelector(`.ila-slideover__label`);
-    aria.Utils.attemptFocus(title_tag);
+window.openSlideover = function (dialogId) {
+    new aria.Dialog(dialogId);
 };
 
 window.closeSlideover = function () {
@@ -138,6 +135,10 @@ aria.Dialog = function (dialogId) {
         this.dialogNode.nextSibling
     );
     this.postNode.tabIndex = 0;
+
+    let title_tag = document.querySelector(`.ila-slideover__label`);
+    title_tag.setAttribute('tabindex', '0');
+    setTimeout(function(){    title_tag.focus();   },500);
 
     this.addListeners();
     aria.openedDialog = this;

--- a/applications/ila-slideovers/ila-slideover.js
+++ b/applications/ila-slideovers/ila-slideover.js
@@ -5,8 +5,8 @@ var aria = aria || {};
 
 aria.Utils = aria.Utils || {};
 
-window.openSlideover = function (dialogId) {
-    new aria.Dialog(dialogId);
+window.openSlideover = async function (dialogId) {
+    await new aria.Dialog(dialogId);
     // Put focus on a button.
     let button_tag = document.querySelector(`#${dialogId} button`);
     console.log(button_tag);
@@ -52,6 +52,27 @@ aria.Utils.focusLastDescendant = function (element) {
   }; // end focusLastDescendant
 
 /**
+ * @description Set focus on descendant nodes until the last focusable element is
+ *       found.
+ * @param element
+ *          DOM node for which to find the last focusable descendant.
+ * @returns {boolean}
+ *  true if a focusable element is found and focus is set.
+ */
+aria.Utils.focusLastDescendant = function (element) {
+    for (var i = element.childNodes.length; i > 0; i--) {
+        var child = element.childNodes[i];
+        if (
+            aria.Utils.attemptFocus(child) ||
+            aria.Utils.focusLastDescendant(child)
+        ) {
+            return true;
+        }
+    }
+    return false;
+}; // end focusFirstDescendant
+
+/**
  * @description Set Attempt to set focus on the current node.
  * @param element
  *          The node to attempt to focus on.
@@ -59,7 +80,7 @@ aria.Utils.focusLastDescendant = function (element) {
  *  true if element is focused.
  */
 aria.Utils.attemptFocus = function (element) {
-    console.debug('Attempting to focus on element:', element);
+    console.log('Attempting to focus on element:', element);
     if (!aria.Utils.isFocusable(element)) {
         console.warn(
             'Attempted to focus on an element that is not focusable.',


### PR DESCRIPTION
+ Removed the 'X' in the slide-over. That was just left-over from the previous banner design.
+ Fix unacceptable link highlight color contrast for small link text, by switching to Altgeld orange (per University brand guide.) UIC or UIS example colors were not impacted by this. 
+ Updates to focus on the slide-over title, to better support screen-readers.

Closed #192 