### PR TITLE
update closeCookieB function to resolve issue

### DIFF
--- a/applications/ila-cookie-banner/CHANGELOG.md
+++ b/applications/ila-cookie-banner/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+All notable changes to the cookie banner will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/applications/ila-cookie-banner/CHANGELOG.md
+++ b/applications/ila-cookie-banner/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+
+### Changed
+
+### Removed
+
+## [1.1.2] - 2025-08-11
+
+### Changed
+
+- The Escape Key will now only change focus if the Cookie Banner is open. (Issue [#230](https://github.com/app-illinois/Design-Resources/issues/230))
+
+## [1.1.1] - 2025-07-31
+
+### Changed
+
+- Sets the cookie at the base domain. Issue (Issue [#226](https://github.com/app-illinois/Design-Resources/issues/226)) & (Issue [#213](https://github.com/app-illinois/Design-Resources/issues/213))
+
+## [1.1.0] - 2025-07-03
+
+### Changed
+
+- Update for compliance accessible keyboard control and color contrast issues. (Issue [#168](https://github.com/app-illinois/Design-Resources/issues/168))
+
+## [1.0.0] - 2025-06-30
+
+### Changed
+
+- Initial release

--- a/applications/ila-cookie-banner/ila-cookie-banner.js
+++ b/applications/ila-cookie-banner/ila-cookie-banner.js
@@ -42,22 +42,28 @@ async function openCookieB(cookiebId) {
 
 function closeCookieB(cookiebId) {
     let cookieb = document.getElementById(cookiebId);
-    cookieb.classList.remove('ila-cookieb--open');
-    cookieb.classList.add('ila-cookieb--closed');
 
-    // Remember that the notice has been dismissed
-    setDismissCookieNotice();
+    // Only move forward if the Cookie Banner is Open
+    if (cookieb.classList.contains('ila-cookieb--open')) {
 
-    // Used to enable scroll on the page
-    document.body.classList.remove('ila-cookieb-noscroll');
+        cookieb.classList.remove('ila-cookieb--open');
+        cookieb.classList.add('ila-cookieb--closed');
 
-    // Used to disable a modal background on the page
-    let modalIDvar = document.getElementById('ilaCookieModal');
-    modalIDvar.classList.remove('ila-cookieb-modal');
+        // Remember that the notice has been dismissed
+        setDismissCookieNotice();
 
-    // Put focus back to the page body on close
-    document.body.setAttribute('tabindex', '-1'); // Focusable but outside tab order
-    document.body.focus();
+        // Used to enable scroll on the page
+        document.body.classList.remove('ila-cookieb-noscroll');
+
+        // Used to disable a modal background on the page
+        let modalIDvar = document.getElementById('ilaCookieModal');
+        modalIDvar.classList.remove('ila-cookieb-modal');
+
+        // Put focus back to the page body on close
+        document.body.setAttribute('tabindex', '-1'); // Focusable but outside tab order
+        document.body.focus();
+
+    }
 }
 
 function manageAutoclose(cookiebId) {


### PR DESCRIPTION
## [1.1.2] - 2025-08-11

### Changed

- The Escape Key will now only change focus if the Cookie Banner is open. (Issue [#230](https://github.com/app-illinois/Design-Resources/issues/230))