### PR TITLE
Add Path attribute to cookie strings

### DIFF
--- a/applications/ila-cookie-banner/ila-cookie-banner.js
+++ b/applications/ila-cookie-banner/ila-cookie-banner.js
@@ -90,11 +90,11 @@ function getBaseDomain() {
 }
 
 function getCookieString(expires) {
-    return "cookie_notice=hide;SameSite=Lax;domain=" + getBaseDomain() + ";expires=" + expires.toUTCString();
+    return "cookie_notice=hide;Path=/;SameSite=Lax;domain=" + getBaseDomain() + ";expires=" + expires.toUTCString();
 }
 
 function getFallBackCookieString(expires) {
-    return "cookie_notice=hide;SameSite=Lax;expires=" + expires.toUTCString();
+    return "cookie_notice=hide;Path=/;SameSite=Lax;expires=" + expires.toUTCString();
 }
 
 

--- a/docs/Cookie-Banner-UIC.html
+++ b/docs/Cookie-Banner-UIC.html
@@ -134,8 +134,7 @@
                 </p>
                 <p><a href="Cookie-Banner.html">Illinois example here.</a></p>
                 <p><a href="Cookie-Banner-UIS.html">UIS example here.</a></p>
-                <button type="button" onclick="openSlideover('ilaCookieSlideover')">
-                    class="il-button ila-cookieb__button">
+                <button type="button" id="ot-sdk-btn" class="ot-sdk-show-settings il-button">
                     About Cookies
                 </button>
                 <p>
@@ -177,8 +176,8 @@
     </footer><!-- #colophon -->
 
     <script data-domain-script="uic" src="js/ila-cookie-banner.js"></script>
-    <!-- 
-    data-comain-script="c2f2262d-b694-4eba-8f4b-142c102b685a" also works 
+    <!--
+    data-comain-script="c2f2262d-b694-4eba-8f4b-142c102b685a" also works
     -->
 </body>
 

--- a/docs/Cookie-Banner-UIS.html
+++ b/docs/Cookie-Banner-UIS.html
@@ -134,8 +134,7 @@
                 </p>
                 <p><a href="Cookie-Banner.html">Illinois example here.</a></p>
                 <p><a href="Cookie-Banner-UIC.html">UIC example here.</a></p>
-                <button type="button" onclick="openSlideover('ilaCookieSlideover')">
-                    class="il-button ila-cookieb__button">
+                <button type="button" id="ot-sdk-btn" class="ot-sdk-show-settings il-button">
                     About Cookies
                 </button>
                 <p>
@@ -177,7 +176,7 @@
     </footer><!-- #colophon -->
 
     <script data-domain-script="uis" src="js/ila-cookie-banner.js"></script>
-    <!-- 
+    <!--
     data-comain-script="698d1fb7-b06b-4591-adbf-ac44ae3ef77b" also works
     -->
 </body>


### PR DESCRIPTION
Add `Path=/` to make the 'do not show this' cookie visible to more of each site.